### PR TITLE
Sequential opendb

### DIFF
--- a/www/SQLitePlugin.js
+++ b/www/SQLitePlugin.js
@@ -127,14 +127,14 @@
   };
 
   SQLitePlugin.prototype.startNextTransaction = function() {
-    var self = this;
+    var _this = this;
     nextTick(function() {
         var txLock;
-        if (!(self.dbname in self.openDBs) || self.openDBs[self.dbname].state !== DB_STATE_OPEN) {
+        if (!(_this.dbname in _this.openDBs) || _this.openDBs[_this.dbname].state !== DB_STATE_OPEN) {
           console.log('cannot start next transaction: database not open');
           return;
         }
-        txLock = txLocks[self.dbname];
+        txLock = txLocks[_this.dbname];
         if (!txLock) {
           console.log('cannot start next transaction: database connection is lost');
           return;

--- a/www/SQLitePlugin.js
+++ b/www/SQLitePlugin.js
@@ -237,17 +237,25 @@
         connections: []
       };
 
-      var options = {};
-      for (var key in this.openargs) {
-        options[key] = this.openargs[key];
-      }
+      var self = this;
+      var openNext = function openNext(connNumber) {
 
-      for (var i = 0; i < maxConnections; i++) {
-        var connectionName = 'connection' + i;
+        var options = {};
+        for (var key in self.openargs) {
+          options[key] = self.openargs[key];
+        }
+
+        var connectionName = 'connection' + connNumber;
         options['connectionName'] = connectionName;
+        var onSuccess = opensuccesscb(connectionName);
 
-        cordova.exec(opensuccesscb(connectionName), openerrorcb, "SQLitePlugin", "open", [options]);
-      }
+        cordova.exec(function() {
+          onSuccess();
+          if (0 <-- connNumber) { openNext(connNumber); }
+        }, openerrorcb, "SQLitePlugin", "open", [options]);        
+      };
+
+      openNext(maxConnections);
     }
   };
 

--- a/www/SQLitePlugin.js
+++ b/www/SQLitePlugin.js
@@ -238,24 +238,32 @@
       };
 
       var self = this;
+      var copyOptions = function() {
+        var options = {};
+        var optionNames = Object.keys(self.openargs);
+        for (var i = 0; i < optionNames.length; i++) {
+          options[optionNames[i]] = self.openargs[optionNames[i]];
+        }
+        return options;
+      }
+
       var openNext = function openNext(connNumber) {
 
-        var options = {};
-        for (var key in self.openargs) {
-          options[key] = self.openargs[key];
-        }
+        var options = copyOptions();
 
         var connectionName = 'connection' + connNumber;
-        options['connectionName'] = connectionName;
         var onSuccess = opensuccesscb(connectionName);
+        options['connectionName'] = connectionName;
 
         cordova.exec(function() {
           onSuccess();
-          if (0 <-- connNumber) { openNext(connNumber); }
+          if (connNumber < maxConnections) {
+            openNext(connNumber + 1);
+          }
         }, openerrorcb, "SQLitePlugin", "open", [options]);        
       };
 
-      openNext(maxConnections);
+      openNext(0);
     }
   };
 

--- a/www/SQLitePlugin.js
+++ b/www/SQLitePlugin.js
@@ -127,12 +127,10 @@
   };
 
   SQLitePlugin.prototype.startNextTransaction = function() {
-    var self;
-    self = this;
-    nextTick((function(_this) {
-      return function() {
+    var self = this;
+    nextTick(function() {
         var txLock;
-        if (!(_this.dbname in _this.openDBs) || _this.openDBs[_this.dbname].state !== DB_STATE_OPEN) {
+        if (!(self.dbname in self.openDBs) || self.openDBs[self.dbname].state !== DB_STATE_OPEN) {
           console.log('cannot start next transaction: database not open');
           return;
         }
@@ -158,8 +156,7 @@
               }
             }
         }
-      };
-    })(this));
+      });
   };
 
   SQLitePlugin.prototype.abortAllPendingTransactions = function() {
@@ -178,13 +175,13 @@
 
   SQLitePlugin.prototype.open = function(success, error) {
     var openerrorcb, opensuccesscb;
+    var _this = this;
+
     if (this.dbname in this.openDBs) {
       console.log('database already open: ' + this.dbname);
-      nextTick((function(_this) {
-        return function() {
+      nextTick(function() {
           success(_this);
-        };
-      })(this));
+        });
     } else {
 
       var maxConnections = 4, okConnections = 0; 
@@ -197,8 +194,7 @@
       }
       
       console.log('OPEN database: ' + this.dbname);
-      opensuccesscb = (function(_this) {
-        return function(connectionName) {
+      opensuccesscb = function(connectionName) {
             return function() {
               var txLock;
               console.log('OPEN database: ' + _this.dbname + ', connection: ' + connectionName + ' - OK');
@@ -229,9 +225,7 @@
               
             };
         };
-      })(this);
-      openerrorcb = (function(_this) {
-        return function() {
+      openerrorcb = function() {
           failed = true;
           console.log('OPEN database: ' + _this.dbname + ' FAILED, aborting any pending transactions');
           if (!!error) {
@@ -240,18 +234,16 @@
           delete _this.openDBs[_this.dbname];
           _this.abortAllPendingTransactions();
         };
-      })(this);
       this.openDBs[this.dbname] = { 
         state: DB_STATE_INIT,
         connections: []
       };
 
-      var self = this;
       var copyOptions = function() {
         var options = {};
-        var optionNames = Object.keys(self.openargs);
+        var optionNames = Object.keys(_this.openargs);
         for (var i = 0; i < optionNames.length; i++) {
-          options[optionNames[i]] = self.openargs[optionNames[i]];
+          options[optionNames[i]] = _this.openargs[optionNames[i]];
         }
         return options;
       }

--- a/www/SQLitePlugin.js
+++ b/www/SQLitePlugin.js
@@ -226,11 +226,11 @@
             };
         };
       openerrorcb = function() {
-          failed = true;
           console.log('OPEN database: ' + _this.dbname + ' FAILED, aborting any pending transactions');
-          if (!!error) {
+          if (!!error && !failed) {
             error(newSQLError('Could not open database'));
           }
+          failed = true;
           delete _this.openDBs[_this.dbname];
           _this.abortAllPendingTransactions();
         };
@@ -250,8 +250,9 @@
 
       var openNext = function openNext(connNumber) {
 
-        var options = copyOptions();
+        connNumber++;
 
+        var options = copyOptions();
         var connectionName = 'connection' + connNumber;
         var onSuccess = opensuccesscb(connectionName);
         options['connectionName'] = connectionName;
@@ -259,7 +260,7 @@
         cordova.exec(function() {
           onSuccess();
           if (connNumber < maxConnections) {
-            openNext(connNumber + 1);
+            openNext(connNumber);
           }
         }, openerrorcb, "SQLitePlugin", "open", [options]);        
       };

--- a/www/SQLitePlugin.js
+++ b/www/SQLitePlugin.js
@@ -186,7 +186,15 @@
         };
       })(this));
     } else {
-      var maxConnections = 4;
+
+      var maxConnections = 4, okConnections = 0; 
+      var failed = false;
+      var successOnce = function(sqlitePlugin) {
+        okConnections++;
+        if (!failed && okConnections == maxConnections) {
+          success(sqlitePlugin);
+        }
+      }
       
       console.log('OPEN database: ' + this.dbname);
       opensuccesscb = (function(_this) {
@@ -204,7 +212,7 @@
               
               var callSuccessAndStartTransaction = function () {
                 if (!!success) {
-                  success(_this);
+                  successOnce(_this);
                 }
                 txLock = txLocks[_this.dbname];
                 if (!!txLock && txLock.queue.length > 0) {
@@ -224,6 +232,7 @@
       })(this);
       openerrorcb = (function(_this) {
         return function() {
+          failed = true;
           console.log('OPEN database: ' + _this.dbname + ' FAILED, aborting any pending transactions');
           if (!!error) {
             error(newSQLError('Could not open database'));


### PR DESCRIPTION
- serialize open database native calls (fixes problem with concurrent opens failing in iOS)
- make it so success/error callbacks are invoked only once despite opening many connections (and that only one of these callbacks is called)
- remove unnecessary closures