### PR TITLE
RNMT-4515 Add support for Android 11

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,7 @@
 # Changes
+### Unreleased
+- An hotfix was applied to ensure the support for Android 11 [RNMT-4515](https://outsystemsrd.atlassian.net/browse/RNMT-4515)
+
 ### cordova-sqlite-storage 3.2.0-OS1
 - Added support for async calls
 

--- a/src/android/io/sqlc/SQLitePlugin.java
+++ b/src/android/io/sqlc/SQLitePlugin.java
@@ -337,6 +337,11 @@ public class SQLitePlugin extends CordovaPlugin {
 
             this.q = new LinkedBlockingQueue<DBQuery>();
             this.openCbc = cbc;
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                Log.v(SQLitePlugin.class.getSimpleName(), "Applying hotfix for Android 11+");
+                this.oldImpl = true;
+            }
         }
 
         public void run() {


### PR DESCRIPTION
### Description
This PR introduces an hotfix to ensure the support for Android 11.

The current version of the plugin is not able to open databases when targeting the SDK 30 and running on devices with Android 11.
The issue was already reported storesafe/cordova-sqlite-storage-dependencies#3 and storesafe#954.
From what I was able to understand, it is related with the permissions changes on Android 11, where the SQLite is unable to open the database file using native C primitive `sqlite3_open_v2`:
- https://github.com/liteglue/Android-sqlite-connector/blob/master/src/io/liteglue/SQLGDatabaseHandle.java#L14
- https://github.com/liteglue/Android-sqlite-connector/blob/master/src/io/liteglue/SQLiteNative.java#L60
- https://github.com/liteglue/Android-sqlite-native-driver/blob/master/native/sqlc.c#L40

Causing the handler to crash with a NullPointerException when throwing an exception:
- https://github.com/liteglue/Android-sqlite-connector/blob/master/src/io/liteglue/SQLiteGlueConnection.java#L12

Summing up, this hotfix will enable the usage of the default Android database provider for Android 11 only, by setting the `oldImpl` to `true`, which is the same behaviour of using the `androidDatabaseProvider: 'system'` setting at the Javascript side.

### Context
Fixes: https://outsystemsrd.atlassian.net/browse/RNMT-4515