### PR TITLE
RNMT-4515 Revert #7 and update dependency libs to fully support Android 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/xpbrew/cordova-sqlite-storage",
   "dependencies": {
-    "cordova-sqlite-storage-dependencies": "2.0.0"
+    "cordova-sqlite-storage-dependencies": "https://github.com/OutSystems/cordova-sqlite-storage-dependencies#2.0.0-OS1"
   },
   "scripts": {
     "clean-spec": "rm -rf spec/[mnp]* && git cl spec/config.xml && git st",

--- a/src/android/io/sqlc/SQLitePlugin.java
+++ b/src/android/io/sqlc/SQLitePlugin.java
@@ -338,11 +338,6 @@ public class SQLitePlugin extends CordovaPlugin {
 
             this.q = new LinkedBlockingQueue<DBQuery>();
             this.openCbc = cbc;
-
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                Log.v(SQLitePlugin.class.getSimpleName(), "Applying hotfix for Android 11+");
-                this.oldImpl = true;
-            }
         }
 
         public void run() {

--- a/src/android/io/sqlc/SQLitePlugin.java
+++ b/src/android/io/sqlc/SQLitePlugin.java
@@ -6,7 +6,6 @@
 
 package io.sqlc;
 
-import android.os.Build;
 import android.util.Log;
 
 import java.io.File;


### PR DESCRIPTION
### Description
This PR reverts the hotfix introduced by #7 and updates the plugin dependency for the `cordova-sqlite-storage-dependencies` component that contains the [sqlite-connector](https://github.com/OutSystems/Android-sqlite-connector/pull/1) and [sqlite-native-driver](https://github.com/OutSystems/Android-sqlite-native-driver/pull/1/) libs with the changes to fully Android apps built with `targetSDKVersion` 30 and running on devices with Android 11.

### Context

Fixes https://outsystemsrd.atlassian.net/browse/RNMT-4515